### PR TITLE
Inject tracking service via React context

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,7 +112,7 @@ Do the following steps to add a new application to this Monorepo.
 2. Depending on the tech stack, make sure that:
    - shared dependencies are configured in the top-level [package.json](./package.json)
    - the `tailwind.config.js` uses the top-level [tailwind.preset.js](./tailwind.preset.js)
-   - the `tsconfig.json` extends the top-level [tsconfig.base.json](./tsconfig.base.json)
+   - the `tsconfig.json` extends the top-level [tsconfig-base.json](./tsconfig-base.json)
 3. The new project needs at least:
    - a `package.json` which defines the project specific dependencies an implements the following scripts:
      - `build`: build the application for production

--- a/packages/dito/Dockerfile.dockerignore
+++ b/packages/dito/Dockerfile.dockerignore
@@ -6,7 +6,7 @@
 !package.json
 !package-lock.json
 !tailwind.preset.js
-!tsconfig.base.json
+!tsconfig-base.json
 !LICENSE
 !SECURITY.md
 !README.md

--- a/packages/shared/components/Button.tsx
+++ b/packages/shared/components/Button.tsx
@@ -1,6 +1,7 @@
 import classNames from "classnames";
-import { cloneElement, type ReactElement } from "react";
+import { cloneElement, useContext, type ReactElement } from "react";
 import { Link } from "react-router-dom";
+import TrackingContext from "../contexts/trackingContext.ts";
 
 type Props = {
   text?: string;
@@ -10,7 +11,6 @@ type Props = {
   iconLeft?: ReactElement;
   iconRight?: ReactElement;
   fullWidth?: boolean;
-  trackButtonClick?: (id?: string, href?: string) => void;
   onClickCallback?: (event: React.MouseEvent<HTMLAnchorElement>) => void;
 };
 
@@ -37,7 +37,6 @@ function Button({
   look,
   size,
   href,
-  trackButtonClick,
   onClickCallback,
   ...props
 }: ButtonProps | ButtonLinkProps) {
@@ -71,10 +70,10 @@ function Button({
     }
   };
 
+  const tracking = useContext(TrackingContext);
+
   const onClick = (event: React.MouseEvent<HTMLAnchorElement>) => {
-    if (trackButtonClick) {
-      trackButtonClick(id, href);
-    }
+    tracking.trackButtonClick(id, href);
     if (onClickCallback) {
       onClickCallback(event);
     }

--- a/packages/shared/contexts/trackingContext.ts
+++ b/packages/shared/contexts/trackingContext.ts
@@ -1,0 +1,6 @@
+import React from "react";
+import noopTracking from "../services/noopTracking";
+
+const TrackingContext = React.createContext(noopTracking);
+
+export default TrackingContext;

--- a/packages/shared/services/noopTracking.tsx
+++ b/packages/shared/services/noopTracking.tsx
@@ -1,0 +1,12 @@
+import SharedTracking from "./sharedTracking.tsx";
+
+class NoopTracking implements SharedTracking {
+  trackButtonClick(id: string | undefined, href: string | undefined) {
+    console.debug(
+      `Button click not tracked for id="${id}" and href="${href}". Inject a tracking service into the context to enable tracking.`,
+    );
+  }
+}
+
+const noopTracking: SharedTracking = new NoopTracking();
+export default noopTracking;

--- a/packages/shared/services/sharedTracking.tsx
+++ b/packages/shared/services/sharedTracking.tsx
@@ -1,0 +1,3 @@
+export default interface SharedTracking {
+  trackButtonClick(id: string | undefined, href: string | undefined): void;
+}

--- a/packages/tool-finder/Dockerfile.dockerignore
+++ b/packages/tool-finder/Dockerfile.dockerignore
@@ -6,7 +6,7 @@
 !package.json
 !package-lock.json
 !tailwind.preset.js
-!tsconfig.base.json
+!tsconfig-base.json
 
 # Whitelist for packages/tool-finder
 !packages/tool-finder/src/

--- a/packages/tool-finder/src/App.tsx
+++ b/packages/tool-finder/src/App.tsx
@@ -8,9 +8,9 @@ import Breadcrumbs, {
 } from "@digitalcheck/shared/components/Breadcrumbs";
 import FeedbackBanner from "@digitalcheck/shared/components/FeedbackBanner";
 import Footer from "@digitalcheck/shared/components/Footer";
-import PageHeader from "@digitalcheck/shared/components/PageHeader";
 import ScrollToTop from "@digitalcheck/shared/components/ScrollToTop";
 import useStorage from "@digitalcheck/shared/services/useStorage";
+import PageHeader from "components/PageHeader";
 
 import type { Reason } from "models/Reason";
 import type { Ressort } from "models/Ressort";

--- a/packages/tool-finder/src/MaintenanceModeApp.tsx
+++ b/packages/tool-finder/src/MaintenanceModeApp.tsx
@@ -1,5 +1,5 @@
 import Container from "@digitalcheck/shared/components/Container";
-import PageHeader from "@digitalcheck/shared/components/PageHeader";
+import PageHeader from "components/PageHeader";
 import { Link, Route, Routes } from "react-router-dom";
 import { PATH_IMPRINT, PATH_INFO } from "routes";
 import Imprint from "routes/Imprint";

--- a/packages/tool-finder/src/components/PageHeader.tsx
+++ b/packages/tool-finder/src/components/PageHeader.tsx
@@ -1,6 +1,6 @@
-import bundLogo from "public/img/bund-logo.png";
+import Image from "@digitalcheck/shared/components/Image";
+import bundLogo from "@digitalcheck/shared/public/img/bund-logo.png";
 import { Link } from "react-router-dom";
-import Image from "./Image";
 
 export default function Header() {
   return (

--- a/packages/tool-finder/src/main.tsx
+++ b/packages/tool-finder/src/main.tsx
@@ -1,18 +1,19 @@
+import TrackingContext from "@digitalcheck/shared/contexts/trackingContext.ts";
 import App from "App.tsx";
 import MaintenanceModeApp from "MaintenanceModeApp";
 import React from "react";
 import ReactDOM from "react-dom/client";
 import { BrowserRouter as Router } from "react-router-dom";
-import { enableTracking } from "services/tracking";
 import "style.css";
+import tracking from "./services/tracking.tsx";
 
 const maintenanceMode: boolean =
   import.meta.env.VITE_MAINTENANCE_MODE == "true";
 
-enableTracking();
-
 ReactDOM.createRoot(document.getElementById("root")!).render(
   <React.StrictMode>
-    <Router>{maintenanceMode ? <MaintenanceModeApp /> : <App />}</Router>
+    <TrackingContext.Provider value={tracking}>
+      <Router>{maintenanceMode ? <MaintenanceModeApp /> : <App />}</Router>
+    </TrackingContext.Provider>
   </React.StrictMode>,
 );

--- a/packages/tool-finder/src/routes/DecisionTree.tsx
+++ b/packages/tool-finder/src/routes/DecisionTree.tsx
@@ -4,7 +4,6 @@ import Container from "@digitalcheck/shared/components/Container";
 import Header from "@digitalcheck/shared/components/Header";
 import useTitle from "services/useTitle";
 
-import { trackButtonClick } from "services/tracking";
 import { PATH_RESULT } from "./";
 
 function DecisionTree() {
@@ -37,7 +36,6 @@ function DecisionTree() {
               id: "diagram-guide-page-back-button",
               text: "Zurück",
               href: PATH_RESULT,
-              trackButtonClick,
             },
           ]}
         ></Box>

--- a/packages/tool-finder/src/routes/Diagram.tsx
+++ b/packages/tool-finder/src/routes/Diagram.tsx
@@ -4,7 +4,6 @@ import Container from "@digitalcheck/shared/components/Container";
 import Header from "@digitalcheck/shared/components/Header";
 import useTitle from "services/useTitle";
 
-import { trackButtonClick } from "services/tracking";
 import { PATH_RESULT } from "./";
 
 function Diagram() {
@@ -37,7 +36,6 @@ function Diagram() {
               id: "diagram-guide-page-back-button",
               text: "Zurück",
               href: PATH_RESULT,
-              trackButtonClick,
             },
           ]}
         ></Box>

--- a/packages/tool-finder/src/routes/Flowchart.tsx
+++ b/packages/tool-finder/src/routes/Flowchart.tsx
@@ -2,7 +2,6 @@ import Background from "@digitalcheck/shared/components/Background";
 import Box from "@digitalcheck/shared/components/Box";
 import Container from "@digitalcheck/shared/components/Container";
 import Header from "@digitalcheck/shared/components/Header";
-import { trackButtonClick } from "services/tracking";
 import useTitle from "services/useTitle";
 
 import Button from "@digitalcheck/shared/components/Button";
@@ -108,7 +107,6 @@ Der Start mag Ihnen leichter fallen, wenn Sie als Basis eine zeitliche Abfolge w
             id="flowchart-guide-page-back-button"
             text="Zurück"
             href={PATH_RESULT}
-            trackButtonClick={trackButtonClick}
           />
         </ButtonContainer>
       </Container>

--- a/packages/tool-finder/src/routes/InfoPage.tsx
+++ b/packages/tool-finder/src/routes/InfoPage.tsx
@@ -3,7 +3,6 @@ import BetaBanner from "@digitalcheck/shared/components/BetaBanner";
 import Box from "@digitalcheck/shared/components/Box";
 import Container from "@digitalcheck/shared/components/Container";
 import Header from "@digitalcheck/shared/components/Header";
-import { trackButtonClick } from "services/tracking";
 import useTitle from "services/useTitle";
 import { PATH_QUIZ } from ".";
 
@@ -42,7 +41,6 @@ function InfoPage() {
               text: "Werkzeug finden",
               href: PATH_QUIZ,
               size: "large",
-              trackButtonClick,
             },
           ]}
         ></Box>

--- a/packages/tool-finder/src/routes/QuizPage.tsx
+++ b/packages/tool-finder/src/routes/QuizPage.tsx
@@ -19,7 +19,7 @@ import {
 import { ChangeEvent, Dispatch, SetStateAction } from "react";
 import { UseFormReturn, useForm } from "react-hook-form";
 import { useNavigate } from "react-router";
-import { trackButtonClick, trackSelection } from "services/tracking";
+import tracking from "services/tracking";
 import useTitle from "services/useTitle";
 import { PATH_RESULT } from ".";
 
@@ -100,7 +100,7 @@ function QuizPage({
   };
 
   const onSubmit = () => {
-    trackSelection(ressort, object, reason);
+    tracking.trackSelection(ressort, object, reason);
     navigate(PATH_RESULT);
   };
 
@@ -169,7 +169,6 @@ function QuizPage({
                 text={"Werkzeug suchen"}
                 size={"large"}
                 type={"submit"}
-                trackButtonClick={trackButtonClick}
               />
             </ButtonContainer>
           </Container>

--- a/packages/tool-finder/src/routes/ResultPage.tsx
+++ b/packages/tool-finder/src/routes/ResultPage.tsx
@@ -10,7 +10,7 @@ import { findResultByObjectAndRessort } from "persistance/repository";
 import { useEffect } from "react";
 import { useNavigate } from "react-router-dom";
 import { getImageUrl } from "services/getImageUrl";
-import { trackButtonClick, trackFeedbackClick } from "services/tracking";
+import tracking from "services/tracking";
 import useTitle from "services/useTitle";
 import { PATH_QUIZ } from ".";
 
@@ -70,7 +70,6 @@ function ResultPage({ ressort, object, reason }: ResultPageProps) {
                     href: `/${result.cluster.id}`,
                     size: "small",
                     look: "tertiary",
-                    trackButtonClick,
                   },
                 ]}
               ></Box>
@@ -112,7 +111,6 @@ function ResultPage({ ressort, object, reason }: ResultPageProps) {
               size: "small",
               look: "tertiary",
               href: PATH_QUIZ,
-              trackButtonClick,
             },
           ]}
         ></Box>
@@ -121,7 +119,7 @@ function ResultPage({ ressort, object, reason }: ResultPageProps) {
         ressort={ressort.name}
         object={object.name}
         reason={reason.name}
-        trackFeedbackClick={trackFeedbackClick}
+        trackFeedbackClick={tracking.trackFeedbackClick}
       />
     </>
   ) : (
@@ -141,7 +139,6 @@ function ResultPage({ ressort, object, reason }: ResultPageProps) {
             id: "result-error-page-back-button",
             text: "Zurück",
             href: PATH_QUIZ,
-            trackButtonClick,
           },
         ]}
       ></Box>

--- a/packages/tool-finder/src/services/tracking.tsx
+++ b/packages/tool-finder/src/services/tracking.tsx
@@ -1,3 +1,4 @@
+import SharedTracking from "@digitalcheck/shared/services/sharedTracking.tsx";
 import type { Reason } from "models/Reason";
 import type { Ressort } from "models/Ressort";
 import type { VisualisationObject } from "models/VisualisationObject";
@@ -7,77 +8,82 @@ const EVENT_BUTTON_CLICK = "Button: Click";
 const EVENT_FEEDBACK_CLICK = "Feedback: Click";
 const EVENT_SELECTION_SUBMIT = "Selection: Submit";
 
-const { enableAutoPageviews, enableAutoOutboundTracking, trackEvent } =
-  Plausible({
+class TrackingService implements SharedTracking {
+  plausible = Plausible({
     domain: "visualisieren.digitalcheck.bund.de",
     hashMode: true,
   });
 
-export function enableTracking() {
-  enableAutoPageviews();
-  enableAutoOutboundTracking();
-}
-
-export function trackButtonClick(
-  id: string | undefined,
-  href: string | undefined,
-) {
-  trackEvent(EVENT_BUTTON_CLICK, {
-    props: {
-      id: id ?? "",
-      href: href ?? "",
-    },
-  });
-}
-
-const combine = (...values: string[]) => {
-  return values.join(" --- ");
-};
-
-export function trackSelection(
-  ressort: Ressort | null,
-  object: VisualisationObject | null,
-  reason: Reason | null,
-) {
-  if (!ressort || !object || !reason) {
-    return;
+  constructor() {
+    this.plausible.enableAutoPageviews();
+    this.plausible.enableAutoOutboundTracking();
   }
 
-  const ressortName = ressort.name;
-  const objectName = object.name;
-  const reasonName = reason.name;
+  trackButtonClick(id: string | undefined, href: string | undefined) {
+    this.plausible.trackEvent(EVENT_BUTTON_CLICK, {
+      props: {
+        id: id ?? "",
+        href: href ?? "",
+      },
+    });
+  }
 
-  trackEvent(EVENT_SELECTION_SUBMIT, {
-    props: {
-      ressort: ressortName,
-      object: objectName,
-      reason: reasonName,
-      ressortAndObject: combine(ressortName, objectName),
-      ressortAndReason: combine(ressortName, reasonName),
-      objectAndReason: combine(objectName, reasonName),
-      ressortAndObjectAndReason: combine(ressortName, objectName, reasonName),
-    },
-  });
+  combine = (...values: string[]) => {
+    return values.join(" --- ");
+  };
+
+  trackSelection(
+    ressort: Ressort | null,
+    object: VisualisationObject | null,
+    reason: Reason | null,
+  ) {
+    if (!ressort || !object || !reason) {
+      return;
+    }
+
+    const ressortName = ressort.name;
+    const objectName = object.name;
+    const reasonName = reason.name;
+
+    this.plausible.trackEvent(EVENT_SELECTION_SUBMIT, {
+      props: {
+        ressort: ressortName,
+        object: objectName,
+        reason: reasonName,
+        ressortAndObject: this.combine(ressortName, objectName),
+        ressortAndReason: this.combine(ressortName, reasonName),
+        objectAndReason: this.combine(objectName, reasonName),
+        ressortAndObjectAndReason: this.combine(
+          ressortName,
+          objectName,
+          reasonName,
+        ),
+      },
+    });
+  }
+
+  trackFeedbackClick(
+    question: string,
+    value: number,
+    ressort: string,
+    object: string,
+    reason: string,
+  ) {
+    const valueString = value.toString();
+    this.plausible.trackEvent(EVENT_FEEDBACK_CLICK, {
+      props: {
+        questionAndValue: this.combine(question, valueString),
+        questionAndValueForSelection: this.combine(
+          ressort,
+          object,
+          reason,
+          question,
+          valueString,
+        ),
+      },
+    });
+  }
 }
 
-export function trackFeedbackClick(
-  question: string,
-  value: number,
-  ressort: string,
-  object: string,
-  reason: string,
-) {
-  const valueString = value.toString();
-  trackEvent(EVENT_FEEDBACK_CLICK, {
-    props: {
-      questionAndValue: combine(question, valueString),
-      questionAndValueForSelection: combine(
-        ressort,
-        object,
-        reason,
-        question,
-        valueString,
-      ),
-    },
-  });
-}
+const tracking: TrackingService = new TrackingService();
+export default tracking;


### PR DESCRIPTION
This refactoring simplifies tracking for shared components:
- shared components use a tracking service loaded from context
- the tracking service implements an interface which defines common / shared methods (like button click tracking)
- each project injects their own implementation of the service into the context
- a default noop implementation is injected which only logs the events on debug