### PR TITLE
Change precheck form handling to work w/o JS

### DIFF
--- a/packages/dito/app/routes/vorpruefung.$questionId/route.tsx
+++ b/packages/dito/app/routes/vorpruefung.$questionId/route.tsx
@@ -146,7 +146,7 @@ export default function Index() {
               onChange: (e: React.ChangeEvent<HTMLInputElement>) =>
                 setSelectedOption(e.target.value as Option["value"]),
               formRegister: register,
-              error: errors[question.id],
+              error: errors["answer"],
             }}
           />
           <Container paddingTop="0">


### PR DESCRIPTION
Some changes to the way the form submissions are handled so that the pre-check can be completed without JavaScript enabled. I am not a huge fan of this makeshift solution and would probably prefer a move away from `react-hook-form` instead.

Validation isn't supported yet without JS.