### PR TITLE
Migrate from React Hook Form to RVF

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13220,22 +13220,6 @@
         "react": "^18.3.1"
       }
     },
-    "node_modules/react-hook-form": {
-      "version": "7.52.1",
-      "resolved": "https://registry.npmjs.org/react-hook-form/-/react-hook-form-7.52.1.tgz",
-      "integrity": "sha512-uNKIhaoICJ5KQALYZ4TOaOLElyM+xipord+Ha3crEFhTntdLvWZqVY49Wqd/0GiVCA/f9NjemLeiNPjG7Hpurg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=12.22.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/react-hook-form"
-      },
-      "peerDependencies": {
-        "react": "^16.8.0 || ^17 || ^18 || ^19"
-      }
-    },
     "node_modules/react-is": {
       "version": "16.13.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
@@ -16458,7 +16442,8 @@
     "packages/tool-finder": {
       "name": "@digitalcheck/tool-finder",
       "dependencies": {
-        "react-hook-form": "^7.52.0",
+        "@rvf/react": "^0.0.8",
+        "@rvf/zod": "^0.0.8",
         "react-router-dom": "^6.22.1"
       },
       "engines": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,10 +13,13 @@
         "@digitalservice4germany/angie": "^1.1.1",
         "@digitalservice4germany/style-dictionary": "^2.0.0",
         "@digitalservicebund/icons": "^2.0.0",
+        "@rvf/remix": "^0.0.8",
+        "@rvf/zod": "^0.0.8",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
         "unleash-client": "^5.5.5",
-        "vite-plugin-static-copy": "^1.0.5"
+        "vite-plugin-static-copy": "^1.0.5",
+        "zod": "^3.23.8"
       },
       "devDependencies": {
         "@axe-core/playwright": "^4.9.0",
@@ -3541,6 +3544,68 @@
       "integrity": "sha512-qC/xYId4NMebE6w/V33Fh9gWxLgURiNYgVNObbJl2LZv0GUUItCcCqC5axQSwRaAgaxl2mELq1rMzlswaQ0Zxg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@rvf/core": {
+      "version": "0.0.8",
+      "resolved": "https://registry.npmjs.org/@rvf/core/-/core-0.0.8.tgz",
+      "integrity": "sha512-ZM4qLZ0IxAx29i5ce8vddEvwS/6u6Eptzhgmp8GnfVmkpKCdnU59cEd/7dU/EtzNoIai3uDGwGVknVEsJ61Sjg==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "immer": "^10.0.4"
+      },
+      "peerDependencies": {
+        "@rvf/set-get": ">= 0.0.0 < 1.0.0",
+        "react": "^17.0.2 || ^18.0.0"
+      }
+    },
+    "node_modules/@rvf/react": {
+      "version": "0.0.8",
+      "resolved": "https://registry.npmjs.org/@rvf/react/-/react-0.0.8.tgz",
+      "integrity": "sha512-5zwBvQy6JkHOe+ZWUhKWU4M9a9vXyv5KjBLE1IWi3ssOscvVG3nqf5NW4E5OXLZR4efLuoZ78S0WsCQHBA0fQQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@rvf/core": ">= 0.0.0 < 7.0.0",
+        "@rvf/set-get": ">= 0.0.0 < 1.0.0",
+        "react": "^17.0.2 || ^18.0.0",
+        "react-dom": "^17.0.2 || ^18.0.0"
+      }
+    },
+    "node_modules/@rvf/remix": {
+      "version": "0.0.8",
+      "resolved": "https://registry.npmjs.org/@rvf/remix/-/remix-0.0.8.tgz",
+      "integrity": "sha512-zyA+Mbm4q9cTI9U05mGw6R1m2YppxxIKgUPPZyKHk+cSmekAzdtADBj1adF6/EQQ23ztlODMqmmmahPv4A0VFA==",
+      "license": "MIT",
+      "dependencies": {
+        "@rvf/react": "*"
+      },
+      "peerDependencies": {
+        "@remix-run/node": ">= 1.16.1 <3.0.0",
+        "@remix-run/react": ">= 1.15.0 <3.0.0",
+        "@remix-run/server-runtime": ">= 1.16.1 <3.0.0",
+        "react": "^17.0.2 || ^18.0.0"
+      }
+    },
+    "node_modules/@rvf/set-get": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/@rvf/set-get/-/set-get-0.0.3.tgz",
+      "integrity": "sha512-RkaZUQspeqhSFn6f8xQu3bQd3wX2v80Ibtz5cVsUIaoeMawYkb0DAl1K+JjkubatfsC0Bn29hdMTpmqvWcR1HQ==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "remeda": "^1.2.0"
+      }
+    },
+    "node_modules/@rvf/zod": {
+      "version": "0.0.8",
+      "resolved": "https://registry.npmjs.org/@rvf/zod/-/zod-0.0.8.tgz",
+      "integrity": "sha512-8uTPkbbWsgfSasYbsVMIcgjWKoR3O05MafeM8JVNDMznqZB9nAkeQC/JqwTz0bW6Gw+ZBpdIXioj/jf7trbH+A==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@rvf/core": ">= 0.0.0 < 7.0.0",
+        "@rvf/set-get": ">= 0.0.0 < 1.0.0",
+        "zod": ">= 3.11.0"
+      }
     },
     "node_modules/@testing-library/dom": {
       "version": "10.3.1",
@@ -8985,6 +9050,17 @@
         "node": ">= 4"
       }
     },
+    "node_modules/immer": {
+      "version": "10.1.1",
+      "resolved": "https://registry.npmjs.org/immer/-/immer-10.1.1.tgz",
+      "integrity": "sha512-s2MPrmjovJcoMaHtx6K11Ra7oD05NT97w1IC5zpMkT6Atjr7H8LjaDd81iIxUYpMKSRRNMJE703M1Fhr/TctHw==",
+      "license": "MIT",
+      "peer": true,
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/immer"
+      }
+    },
     "node_modules/import-fresh": {
       "version": "3.3.0",
       "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.0.tgz",
@@ -13470,6 +13546,13 @@
         "url": "https://opencollective.com/unified"
       }
     },
+    "node_modules/remeda": {
+      "version": "1.61.0",
+      "resolved": "https://registry.npmjs.org/remeda/-/remeda-1.61.0.tgz",
+      "integrity": "sha512-caKfSz9rDeSKBQQnlJnVW3mbVdFgxgGWQKq1XlFokqjf+hQD5gxutLGTTY2A/x24UxVyJe9gH5fAkFI63ULw4A==",
+      "license": "MIT",
+      "peer": true
+    },
     "node_modules/require-like": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/require-like/-/require-like-0.1.2.tgz",
@@ -16321,6 +16404,15 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/zod": {
+      "version": "3.23.8",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.23.8.tgz",
+      "integrity": "sha512-XBx9AXhXktjUqnepgTiE5flcKIYWi/rme0Eaj+5Y0lftuGBq+jyRu/md4WnuxqgP1ubdpNCsYEYPxrzVHD8d6g==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
     "node_modules/zwitch": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/zwitch/-/zwitch-2.0.4.tgz",
@@ -16340,8 +16432,7 @@
         "@remix-run/react": "^2.9.1",
         "@remix-run/serve": "^2.9.1",
         "isbot": "^5.1.4",
-        "pdf-lib": "^1.17.1",
-        "react-hook-form": "^7.52.0"
+        "pdf-lib": "^1.17.1"
       },
       "devDependencies": {
         "@remix-run/dev": "^2.8.1",

--- a/package.json
+++ b/package.json
@@ -33,10 +33,13 @@
     "@digitalservice4germany/angie": "^1.1.1",
     "@digitalservice4germany/style-dictionary": "^2.0.0",
     "@digitalservicebund/icons": "^2.0.0",
+    "@rvf/remix": "^0.0.8",
+    "@rvf/zod": "^0.0.8",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "unleash-client": "^5.5.5",
-    "vite-plugin-static-copy": "^1.0.5"
+    "vite-plugin-static-copy": "^1.0.5",
+    "zod": "^3.23.8"
   },
   "devDependencies": {
     "@axe-core/playwright": "^4.9.0",

--- a/packages/dito/app/resources/staticRoutes.ts
+++ b/packages/dito/app/resources/staticRoutes.ts
@@ -1,7 +1,10 @@
+const PRE_CHECK_PDF = "digitalcheck-vorpruefung.pdf";
+
 export const PATH_LANDING: string = "/";
 export const PATH_PRECHECK: string = "/vorpruefung";
 export const PATH_RESULT: string = `${PATH_PRECHECK}/ergebnis`;
 export const PATH_ASSESSMENT: string = `${PATH_RESULT}/einschaetzung`;
+export const PATH_ASSESSMENT_PDF: string = `${PATH_ASSESSMENT}/${PRE_CHECK_PDF}`;
 export const PATH_METHODS = "/methoden";
 export const PATH_METHODS_RESPONSIBLE_ACTORS = `${PATH_METHODS}/zustaendige-akteurinnen`;
 export const PATH_METHODS_TASKS_PROCESSES = `${PATH_METHODS}/ablaeufe-aufgaben-erfassen`;
@@ -11,8 +14,7 @@ export const PATH_METHODS_TECHNICAL_FEASIBILITY = `${PATH_METHODS}/technische-um
 export const PATH_IMPRINT: string = "/impressum";
 export const PATH_PRIVACY: string = "/datenschutz";
 export const PATH_A11Y: string = "/barrierefreiheit";
-export const PATH_PRECHECK_PDF: string =
-  "/download/digitalcheck-vorpruefung.pdf";
+export const PATH_PRECHECK_PDF: string = `/download/${PRE_CHECK_PDF}`;
 export const PATH_DOCUMENTATION_PDF: string =
   "/download/digitalcheck-begleitende-dokumentation.pdf";
 

--- a/packages/dito/app/routes/vorpruefung.$questionId/route.tsx
+++ b/packages/dito/app/routes/vorpruefung.$questionId/route.tsx
@@ -148,7 +148,7 @@ export default function Index() {
               selectedValue: selectedOption,
               onChange: (e: React.ChangeEvent<HTMLInputElement>) =>
                 setSelectedOption(e.target.value as Option["value"]),
-              error: form.error("answer") ?? undefined,
+              error: form.error("answer"),
             }}
           />
           <Container paddingTop="0">

--- a/packages/dito/app/routes/vorpruefung.$questionId/route.tsx
+++ b/packages/dito/app/routes/vorpruefung.$questionId/route.tsx
@@ -8,19 +8,17 @@ import {
   json,
   type LoaderFunctionArgs,
 } from "@remix-run/node";
-import {
-  MetaFunction,
-  redirect,
-  useFetcher,
-  useLoaderData,
-} from "@remix-run/react";
+import { MetaFunction, redirect, useLoaderData } from "@remix-run/react";
+import { useForm, validationError } from "@rvf/remix";
+import { withZod } from "@rvf/zod";
 import { useEffect, useState } from "react";
-import { useForm } from "react-hook-form";
 import { preCheck, siteMeta } from "resources/content";
+import { PATH_PRECHECK } from "resources/staticRoutes";
 import {
   getAnswersFromCookie,
   getHeaderFromCookie,
 } from "utils/cookies.server";
+import { z } from "zod";
 import PreCheckNavigation from "./PreCheckNavigation";
 
 const { questions, answerOptions, nextButton } = preCheck;
@@ -50,14 +48,35 @@ export async function loader({ request, params }: LoaderFunctionArgs) {
   return json({ questionIdx, question: questions[questionIdx], answers });
 }
 
+const validator = withZod(
+  z.object({
+    answer: z
+      .string({ required_error: "Bitte wählen Sie eine Option aus." })
+      .refine(
+        (answer) => Object.keys(answerOptions).includes(answer),
+        "Bitte wählen Sie eine existierende Option aus.",
+      ),
+    questionId: z
+      .string({ required_error: "Bitte geben Sie eine Frage an." })
+      .refine(
+        (questionId) => questions.map((q) => q.id).includes(questionId),
+        "Bitte wählen Sie eine existierende Frage aus.",
+      ),
+  }),
+);
+
 export async function action({ request }: ActionFunctionArgs) {
-  const cookie = await getAnswersFromCookie(request);
-  const formData = await request.formData();
-  const { questionId, nextLink, answer } = Object.fromEntries(formData);
-  if (typeof questionId !== "string" || typeof nextLink !== "string") {
-    return redirect("/vorpruefung", { status: 400 });
+  const result = await validator.validate(await request.formData());
+
+  if (result.error) {
+    return validationError(result.error);
   }
+  const { questionId, answer } = result.data;
+
+  const cookie = await getAnswersFromCookie(request);
   cookie.answers[questionId] = answer as Option["value"];
+  const nextLink =
+    questions.find((q) => q.id === questionId)?.nextLink ?? PATH_PRECHECK;
 
   return redirect(nextLink, await getHeaderFromCookie(cookie));
 }
@@ -90,35 +109,16 @@ export type Answers = {
 export default function Index() {
   const { question, answers } = useLoaderData<typeof loader>();
   const existingAnswer = answers?.[question.id];
-  const fetcher = useFetcher();
-  const {
-    register,
-    handleSubmit,
-    formState: { errors },
-    setValue,
-  } = useForm();
-  const [selectedOption, setSelectedOption] = useState<
-    Option["value"] | undefined
-  >(existingAnswer);
+  const [selectedOption, setSelectedOption] =
+    useState<Option["value"]>(existingAnswer);
+  const form = useForm({
+    validator,
+    method: "post",
+  });
 
   useEffect(() => {
     setSelectedOption(existingAnswer);
-    // needed to keep data in sync with the form
-    setValue(question.id, existingAnswer);
-  }, [question.id, existingAnswer, setValue]);
-
-  const onSubmit = (data: Record<string, string>) => {
-    fetcher.submit(
-      {
-        questionId: question.id,
-        nextLink: question.nextLink,
-        answer: data[question.id],
-      },
-      {
-        method: "post",
-      },
-    );
-  };
+  }, [existingAnswer, setSelectedOption, question.id]);
 
   const options: Option[] = Object.entries(answerOptions).map(
     ([value, text]) => ({ value: value as Option["value"], text }),
@@ -130,7 +130,8 @@ export default function Index() {
         <PreCheckNavigation question={question} answers={answers ?? {}} />
       </div>
       <section>
-        <fetcher.Form className="pt-32" onSubmit={handleSubmit(onSubmit)}>
+        <form {...form.getFormProps()}>
+          <input type="hidden" name="questionId" value={question.id} />
           <Question
             paddingBottom="32"
             box={{
@@ -142,13 +143,12 @@ export default function Index() {
               content: question.text ? { markdown: question.text } : undefined,
             }}
             radio={{
-              name: question.id,
+              name: "answer",
               options: options,
               selectedValue: selectedOption,
               onChange: (e: React.ChangeEvent<HTMLInputElement>) =>
                 setSelectedOption(e.target.value as Option["value"]),
-              formRegister: register,
-              error: errors[question.id],
+              error: form.error("answer") ?? undefined,
             }}
           />
           <Container paddingTop="0">
@@ -168,7 +168,7 @@ export default function Index() {
               ></Button>
             </ButtonContainer>
           </Container>
-        </fetcher.Form>
+        </form>
         {question.hint && (
           <Container paddingTop="0">
             <InlineNotice

--- a/packages/dito/app/routes/vorpruefung.ergebnis/ResultNegative.tsx
+++ b/packages/dito/app/routes/vorpruefung.ergebnis/ResultNegative.tsx
@@ -67,12 +67,12 @@ export default function ResultNegative({
             <Textarea
               name="negativeReasoning"
               label={assessment.form.reasonLabel}
-              error={form.error("negativeReasoning") ?? undefined}
+              error={form.error("negativeReasoning")}
             />
             <Input
               name="title"
               label={assessment.form.policyTitleLabel}
-              error={form.error("title") ?? undefined}
+              error={form.error("title")}
             />
             <Button
               text={assessment.form.downloadPdfButton.text}

--- a/packages/dito/app/routes/vorpruefung.ergebnis_.einschaetzung.tsx
+++ b/packages/dito/app/routes/vorpruefung.ergebnis_.einschaetzung.tsx
@@ -51,7 +51,7 @@ export default function Assessment() {
           <Input
             name="title"
             label={assessment.form.policyTitleLabel}
-            error={form.error("title") ?? undefined}
+            error={form.error("title")}
           />
           <br />
           <ButtonContainer>

--- a/packages/dito/package.json
+++ b/packages/dito/package.json
@@ -27,8 +27,7 @@
     "@remix-run/react": "^2.9.1",
     "@remix-run/serve": "^2.9.1",
     "isbot": "^5.1.4",
-    "pdf-lib": "^1.17.1",
-    "react-hook-form": "^7.52.0"
+    "pdf-lib": "^1.17.1"
   },
   "devDependencies": {
     "@remix-run/dev": "^2.8.1",

--- a/packages/dito/tests/playwright/e2e/preCheckQuestions.spec.ts
+++ b/packages/dito/tests/playwright/e2e/preCheckQuestions.spec.ts
@@ -135,6 +135,7 @@ test.describe("test questions form", () => {
     await expect(page).toHaveURL(questions[2].url);
     await page.getByLabel("Nein").click();
     await page.getByRole("button", { name: "Übernehmen" }).click();
+    await page.waitForURL(questions[3].url);
     await page.goto(questions[4].url);
     await expect(page).toHaveURL(questions[3].url);
   });

--- a/packages/dito/tests/playwright/e2e/preCheckQuestions.spec.ts
+++ b/packages/dito/tests/playwright/e2e/preCheckQuestions.spec.ts
@@ -76,6 +76,7 @@ test.describe("test questions form", () => {
   }) => {
     // was a bit of a hassle to get the cookie and react-hook-form to work together with useEffect
     // that's why the test is a bit more extensive than it could be
+    // we've sinced moved to using rvf but we'll keep it like this for now
     await page.goto(PATH_PRECHECK);
     await page.getByRole("link", { name: "Digitalbezug einschätzen" }).click();
     await page.getByLabel("Ja").click();

--- a/packages/shared/components/Input.tsx
+++ b/packages/shared/components/Input.tsx
@@ -1,17 +1,16 @@
 import classNames from "classnames";
-import type { GlobalError, UseFormRegisterReturn } from "react-hook-form";
 import InputError from "./InputError";
 import InputLabel from "./InputLabel";
 
 export type InputProps = Readonly<{
+  name: string;
   label?: string;
   type?: string;
   prefix?: string;
   suffix?: string;
   helperText?: string;
   width?: "3" | "5" | "7" | "10" | "16" | "24" | "36" | "54";
-  register: UseFormRegisterReturn;
-  error?: GlobalError;
+  error?: string;
 }>;
 
 const widthClass = (width: string) => {
@@ -28,6 +27,7 @@ const widthClass = (width: string) => {
 };
 
 export default function Input({
+  name,
   label,
   type = "text",
   prefix,
@@ -35,9 +35,7 @@ export default function Input({
   helperText,
   width,
   error,
-  register,
 }: InputProps) {
-  const { name } = register;
   const errorId = `${name}-error`;
   const helperId = `${name}-helper`;
 
@@ -48,8 +46,8 @@ export default function Input({
         {prefix && <div className="ds-input-prefix">{prefix}</div>}
         <input
           id={name}
+          name={name}
           type={type}
-          {...register}
           className={classNames(
             "ds-input forced-color-adjust-none",
             { "has-error": error },
@@ -70,7 +68,7 @@ export default function Input({
       <div className="label-text mt-6" id={helperId}>
         {helperText}
       </div>
-      {error && <InputError id={errorId}>{error.message}</InputError>}
+      {error && <InputError id={errorId}>{error}</InputError>}
     </div>
   );
 }

--- a/packages/shared/components/Input.tsx
+++ b/packages/shared/components/Input.tsx
@@ -10,7 +10,7 @@ export type InputProps = Readonly<{
   suffix?: string;
   helperText?: string;
   width?: "3" | "5" | "7" | "10" | "16" | "24" | "36" | "54";
-  error?: string;
+  error?: string | null;
 }>;
 
 const widthClass = (width: string) => {
@@ -57,7 +57,7 @@ export default function Input({
           aria-describedby={[error && errorId, helperText && helperId].join(
             " ",
           )}
-          aria-errormessage={error && errorId}
+          aria-errormessage={error ? errorId : undefined}
         />
         {suffix && (
           <div className="ds-input-suffix" aria-hidden="true">

--- a/packages/shared/components/RadioGroup.tsx
+++ b/packages/shared/components/RadioGroup.tsx
@@ -1,9 +1,4 @@
 import { ChangeEvent } from "react";
-import type {
-  FieldValues,
-  GlobalError,
-  UseFormRegister,
-} from "react-hook-form";
 import InputError from "./InputError";
 
 export type RadioOptionsProps = {
@@ -17,8 +12,7 @@ export type RadioGroupProps = {
   options: RadioOptionsProps;
   selectedValue?: string;
   onChange?: (event: ChangeEvent<HTMLInputElement>) => void;
-  formRegister: UseFormRegister<FieldValues>;
-  error?: GlobalError;
+  error?: string;
 };
 
 const RadioGroup = ({
@@ -26,7 +20,6 @@ const RadioGroup = ({
   options,
   selectedValue,
   onChange,
-  formRegister,
   error,
 }: RadioGroupProps) => {
   const hasError = !!error;
@@ -37,7 +30,7 @@ const RadioGroup = ({
       role="radiogroup"
       aria-required={true}
       aria-errormessage={errorId}
-      aria-invalid={!!error}
+      aria-invalid={hasError}
     >
       <ul className="ds-stack-16 border-0 p-0 m-0">
         {options.map(({ value, text, subText }) => {
@@ -47,15 +40,13 @@ const RadioGroup = ({
           return (
             <li className="flex items-center" key={value}>
               <input
+                name={name}
                 type="radio"
                 id={id}
                 value={value}
                 className="ds-radio"
                 checked={checked}
-                {...formRegister(name, {
-                  required: "Bitte wählen Sie eine Option aus.",
-                  onChange: onChange,
-                })}
+                onChange={onChange}
                 aria-describedby={errorId}
               />
               <label htmlFor={id}>
@@ -67,9 +58,7 @@ const RadioGroup = ({
         })}
       </ul>
 
-      {error && errorId && (
-        <InputError id={errorId}>{error.message}</InputError>
-      )}
+      {error && errorId && <InputError id={errorId}>{error}</InputError>}
     </div>
   );
 };

--- a/packages/shared/components/RadioGroup.tsx
+++ b/packages/shared/components/RadioGroup.tsx
@@ -1,4 +1,4 @@
-import { ChangeEvent, RefCallback } from "react";
+import type { ChangeEvent } from "react";
 import InputError from "./InputError";
 
 export type RadioOptionsProps = {
@@ -11,7 +11,6 @@ export type RadioGroupProps = {
   name: string;
   options: RadioOptionsProps;
   selectedValue?: string;
-  radioGroupRef?: RefCallback<HTMLInputElement>;
   onChange?: (event: ChangeEvent<HTMLInputElement>) => void;
   error?: string | null;
 };
@@ -20,7 +19,6 @@ const RadioGroup = ({
   name,
   options,
   selectedValue,
-  radioGroupRef,
   onChange,
   error,
 }: RadioGroupProps) => {
@@ -45,7 +43,6 @@ const RadioGroup = ({
                 name={name}
                 type="radio"
                 id={id}
-                ref={radioGroupRef}
                 value={value}
                 className="ds-radio"
                 checked={checked}

--- a/packages/shared/components/RadioGroup.tsx
+++ b/packages/shared/components/RadioGroup.tsx
@@ -1,4 +1,4 @@
-import { ChangeEvent } from "react";
+import { ChangeEvent, RefCallback } from "react";
 import InputError from "./InputError";
 
 export type RadioOptionsProps = {
@@ -11,6 +11,7 @@ export type RadioGroupProps = {
   name: string;
   options: RadioOptionsProps;
   selectedValue?: string;
+  radioGroupRef?: RefCallback<HTMLInputElement>;
   onChange?: (event: ChangeEvent<HTMLInputElement>) => void;
   error?: string;
 };
@@ -19,6 +20,7 @@ const RadioGroup = ({
   name,
   options,
   selectedValue,
+  radioGroupRef,
   onChange,
   error,
 }: RadioGroupProps) => {
@@ -43,6 +45,7 @@ const RadioGroup = ({
                 name={name}
                 type="radio"
                 id={id}
+                ref={radioGroupRef}
                 value={value}
                 className="ds-radio"
                 checked={checked}

--- a/packages/shared/components/RadioGroup.tsx
+++ b/packages/shared/components/RadioGroup.tsx
@@ -13,7 +13,7 @@ export type RadioGroupProps = {
   selectedValue?: string;
   radioGroupRef?: RefCallback<HTMLInputElement>;
   onChange?: (event: ChangeEvent<HTMLInputElement>) => void;
-  error?: string;
+  error?: string | null;
 };
 
 const RadioGroup = ({

--- a/packages/shared/components/Select.tsx
+++ b/packages/shared/components/Select.tsx
@@ -1,7 +1,6 @@
 import classNames from "classnames";
 import type { ReactNode } from "react";
 import { ChangeEvent } from "react";
-import { FieldValues, GlobalError, UseFormRegister } from "react-hook-form";
 import InputError from "./InputError";
 
 export type SelectOptionsProps = {
@@ -16,9 +15,8 @@ export type SelectProps = {
   altLabel?: string;
   placeholder?: string;
   value?: string;
-  onChange?: (event: ChangeEvent<HTMLInputElement>) => void;
-  formRegister: UseFormRegister<FieldValues>;
-  error?: GlobalError;
+  onChange?: (event: ChangeEvent<HTMLSelectElement>) => void;
+  error?: string | null;
 };
 
 const Select = ({
@@ -28,7 +26,6 @@ const Select = ({
   placeholder,
   value,
   onChange,
-  formRegister,
   error,
 }: SelectProps) => {
   const hasError = !!error;
@@ -42,13 +39,11 @@ const Select = ({
       <label htmlFor={name}>{label}</label>
 
       <select
+        name={name}
         id={name}
         className={selectClassName}
         value={value}
-        {...formRegister(name, {
-          required: "Bitte wählen Sie eine Option aus.",
-          onChange: onChange,
-        })}
+        onChange={onChange}
         aria-required={true}
         aria-invalid={hasError}
         aria-describedby={errorId}
@@ -64,9 +59,7 @@ const Select = ({
         })}
       </select>
 
-      {error && errorId && (
-        <InputError id={errorId}>{error.message}</InputError>
-      )}
+      {error && errorId && <InputError id={errorId}>{error}</InputError>}
     </>
   );
 };

--- a/packages/shared/components/Textarea.tsx
+++ b/packages/shared/components/Textarea.tsx
@@ -1,27 +1,25 @@
 import classNames from "classnames";
 import type { ReactNode } from "react";
-import type { GlobalError, UseFormRegisterReturn } from "react-hook-form";
 import InputError from "./InputError";
 import InputLabel from "./InputLabel";
 import RichText from "./RichText";
 
 type TextareaProps = Readonly<{
+  name: string;
   description?: string;
   label?: ReactNode;
   placeholder?: string;
   formId?: string;
-  register: UseFormRegisterReturn;
-  error?: GlobalError;
+  error?: string;
 }>;
 
 const Textarea = ({
+  name,
   description,
   label,
-  register,
   error,
   ...props
 }: TextareaProps) => {
-  const { name } = register;
   const errorId = `${name}-error`;
 
   return (
@@ -38,8 +36,8 @@ const Textarea = ({
         <RichText className="ds-body-01-reg" markdown={description} />
       )}
       <textarea
+        name={name}
         id={name}
-        {...register}
         className={classNames(
           "ds-textarea forced-color-adjust-none placeholder-gray-600",
           {
@@ -51,7 +49,7 @@ const Textarea = ({
         aria-errormessage={error && errorId}
         {...props}
       />
-      {error && <InputError id={errorId}>{error.message}</InputError>}
+      {error && <InputError id={errorId}>{error}</InputError>}
     </div>
   );
 };

--- a/packages/shared/components/Textarea.tsx
+++ b/packages/shared/components/Textarea.tsx
@@ -10,7 +10,7 @@ type TextareaProps = Readonly<{
   label?: ReactNode;
   placeholder?: string;
   formId?: string;
-  error?: string;
+  error?: string | null;
 }>;
 
 const Textarea = ({
@@ -45,8 +45,8 @@ const Textarea = ({
           },
         )}
         aria-invalid={error !== undefined}
-        aria-describedby={error && errorId}
-        aria-errormessage={error && errorId}
+        aria-describedby={error ? errorId : undefined}
+        aria-errormessage={error ? errorId : undefined}
         {...props}
       />
       {error && <InputError id={errorId}>{error}</InputError>}

--- a/packages/tool-finder/package.json
+++ b/packages/tool-finder/package.json
@@ -21,7 +21,8 @@
     "typecheck": "tsc"
   },
   "dependencies": {
-    "react-hook-form": "^7.52.0",
+    "@rvf/react": "^0.0.8",
+    "@rvf/zod": "^0.0.8",
     "react-router-dom": "^6.22.1"
   },
   "engines": {

--- a/packages/tool-finder/src/routes/QuizPage.tsx
+++ b/packages/tool-finder/src/routes/QuizPage.tsx
@@ -159,12 +159,13 @@ function QuizPage({
               },
             }}
             radio={{
-              name: "object",
               selectedValue: object?.id,
-              onChange: onChangeObject,
               options: mapToRadioOptions(objects),
-              formRegister: register,
-              error: errors["object"],
+              ...register("object", {
+                onChange: onChangeReason,
+                required: "Bitte wählen Sie ein Objekt aus.",
+              }),
+              error: String(errors["object"]?.message),
             }}
           />
           <Question
@@ -181,12 +182,13 @@ function QuizPage({
               },
             }}
             radio={{
-              name: "reason",
               selectedValue: reason?.id,
-              onChange: onChangeReason,
               options: mapToRadioOptions(reasons),
-              formRegister: register,
-              error: errors["reason"],
+              ...register("object", {
+                onChange: onChangeObject,
+                required: "Bitte wählen Sie einen Grund aus.",
+              }),
+              error: String(errors["reason"]?.message),
             }}
           />
           <Container paddingTop="0" paddingBottom="80">

--- a/packages/tool-finder/src/routes/QuizPage.tsx
+++ b/packages/tool-finder/src/routes/QuizPage.tsx
@@ -92,12 +92,16 @@ function QuizPage({
   const onChangeRessort = (e: ChangeEvent<HTMLInputElement>) => {
     onChangeHandler(e.target.value, setRessort, ressorts);
   };
-  const onChangeObject = (e: ChangeEvent<HTMLInputElement>) => {
-    onChangeHandler(e.target.value, setObject, objects);
-  };
-  const onChangeReason = (e: ChangeEvent<HTMLInputElement>) => {
-    onChangeHandler(e.target.value, setReason, reasons);
-  };
+  const { ref: objectRef, ...registerObject } = register("object", {
+    onChange: (e: ChangeEvent<HTMLInputElement>) =>
+      onChangeHandler(e.target.value, setObject, objects),
+    required: "Bitte wählen Sie einen Grund aus.",
+  });
+  const { ref: reasonRef, ...registerReason } = register("reason", {
+    onChange: (e: ChangeEvent<HTMLInputElement>) =>
+      onChangeHandler(e.target.value, setReason, reasons),
+    required: "Bitte wählen Sie ein Objekt aus.",
+  });
 
   const onSubmit = () => {
     trackSelection(ressort, object, reason);
@@ -161,11 +165,9 @@ function QuizPage({
             radio={{
               selectedValue: object?.id,
               options: mapToRadioOptions(objects),
-              ...register("object", {
-                onChange: onChangeReason,
-                required: "Bitte wählen Sie ein Objekt aus.",
-              }),
-              error: String(errors["object"]?.message),
+              radioGroupRef: objectRef,
+              ...registerObject,
+              error: errors["object"] ? String(errors["object"]?.message) : "",
             }}
           />
           <Question
@@ -184,11 +186,9 @@ function QuizPage({
             radio={{
               selectedValue: reason?.id,
               options: mapToRadioOptions(reasons),
-              ...register("object", {
-                onChange: onChangeObject,
-                required: "Bitte wählen Sie einen Grund aus.",
-              }),
-              error: String(errors["reason"]?.message),
+              radioGroupRef: reasonRef,
+              ...registerReason,
+              error: errors["reason"] ? String(errors["reason"]?.message) : "",
             }}
           />
           <Container paddingTop="0" paddingBottom="80">


### PR DESCRIPTION
This PR migrates both dito and tool-finder away from react-hook-form and to [rvf](https://www.rvf-js.io/). This package is still in alpha so there will be breaking changes, but it builds upon an existing solution [React Validated Forms](https://www.remix-validated-form.io/) (hence the name) and already feels nicer to work with. Let me know if you feel confident enough to merge this or would rather wait, go with `React Validated Forms v5` or one of the other options below. The author seems to be [reasonably happy with the current state](https://github.com/airjp73/remix-validated-form/discussions/364), but it's still taking him some time it seems.

Other options I considered were:
- [Conform](https://conform.guide/): Looks good, I like the docs, but prefer the server side syntax of rvf. Totally fine, though.
- [Remix Forms](https://remix-forms.seasoned.cc/): Wrapper around `React Hook Form`. Liked the client side syntax a little less.